### PR TITLE
Change CSS so the side-bar shows up in landscape mode on mobile

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -12,3 +12,10 @@
   opacity: 0;
   transform: scale(0.95);
 }
+
+@media only screen and (orientation: landscape) and (max-width: 1023px) {
+  .lg\:flex {
+    display: flex;
+    max-width: 45%;
+  }
+}


### PR DESCRIPTION
If your mobile screen doesn't have an insane 1024px width or more, it'll now show the side bar if you're holding your phone in landscape mode. It'll enforce a maximum width of less than half of your screen. Just flip back to portrait to have a better working view, once you've imported your task order and/or saved your config.

This fixes #12, although perhaps the text at the top of the page should probably be changed too in order to explain to mobile users that they should rotate their phone if they want to import/export/save. I'll leave the wording up to you.